### PR TITLE
fix move, changing time type & zone

### DIFF
--- a/clog.q
+++ b/clog.q
@@ -52,7 +52,7 @@ if[x~"vwap2";t:`trade;f:{[p;s](-10#s)wavg -10#p};
   vwap::`sym xkey select sym,vwap:f'[price;size]from .u.t}]
 
 / vwap last minute (60000 milliseconds)
-if[x~"vwap3";t:`trade;f:{[t;p;s](n#s)wavg(n:(1+t bin("t"$.z.Z)-60000)-count t)#p};
+if[x~"vwap3";t:`trade;f:{[t;p;s](n#s)wavg(n:(1+t bin("n"$.z.Z)-60000000000)-count t)#p};
  upd:{[t;x].[`.u.t;();,'';select time,price,size by sym from x];
   vwap::`sym xkey select sym,vwap:f'[time;price;size]from .u.t}]
   

--- a/clog.q
+++ b/clog.q
@@ -31,7 +31,7 @@ if[x~"vwap1";t:`trade;
 ind:{[t;i](key t)!flip(flip value t)@'\:i}
 if[x~"move";t:`trade;
  upd:{[t;x].[`.u.t;();,'';select time,size*price,size by sym from x];
-  move::((last each) each t)-ind[t:delete time from .u.t;exec time bin'-60000000000+"n"$.z.Z from .u.t]}]
+  move::((last each) each t)-ind[t:delete time from .u.t;exec time bin'-0D00:01+.z.N from .u.t]}]
 
 / high low close volume
 if[x~"hlcv";t:`trade;hlcv:([sym:()]high:();low:();price:();size:());
@@ -52,7 +52,7 @@ if[x~"vwap2";t:`trade;f:{[p;s](-10#s)wavg -10#p};
   vwap::`sym xkey select sym,vwap:f'[price;size]from .u.t}]
 
 / vwap last minute (60000 milliseconds)
-if[x~"vwap3";t:`trade;f:{[t;p;s](n#s)wavg(n:(1+t bin("n"$.z.Z)-60000000000)-count t)#p};
+if[x~"vwap3";t:`trade;f:{[t;p;s](n#s)wavg(n:(1+t bin(.z.N)-0D00:01)-count t)#p};
  upd:{[t;x].[`.u.t;();,'';select time,price,size by sym from x];
   vwap::`sym xkey select sym,vwap:f'[time;price;size]from .u.t}]
   

--- a/clog.q
+++ b/clog.q
@@ -31,7 +31,7 @@ if[x~"vwap1";t:`trade;
 ind:{[t;i](key t)!flip(flip value t)@'\:i}
 if[x~"move";t:`trade;
  upd:{[t;x].[`.u.t;();,'';select time,size*price,size by sym from x];
-  move::((last each) each t)-ind[t:delete time from .u.t;exec time bin'-60000+"t"$.z.z from .u.t]}]
+  move::((last each) each t)-ind[t:delete time from .u.t;exec time bin'-60000000000+"n"$.z.Z from .u.t]}]
 
 / high low close volume
 if[x~"hlcv";t:`trade;hlcv:([sym:()]high:();low:();price:();size:());

--- a/clog.q
+++ b/clog.q
@@ -52,7 +52,7 @@ if[x~"vwap2";t:`trade;f:{[p;s](-10#s)wavg -10#p};
   vwap::`sym xkey select sym,vwap:f'[price;size]from .u.t}]
 
 / vwap last minute (60000 milliseconds)
-if[x~"vwap3";t:`trade;f:{[t;p;s](n#s)wavg(n:(1+t bin(.z.N)-0D00:01)-count t)#p};
+if[x~"vwap3";t:`trade;f:{[t;p;s](n#s)wavg(n:(1+t bin .z.N-0D00:01)-count t)#p};
  upd:{[t;x].[`.u.t;();,'';select time,price,size by sym from x];
   vwap::`sym xkey select sym,vwap:f'[time;price;size]from .u.t}]
   


### PR DESCRIPTION
Change to commonly used datatype in tick. 
Changed to use localtime as per tick for time comparisons, instead of UTC. 

Changes so that it runs 'out of the box' with tick.

For datatype change (1 sec difference calc) , before
```q
q)0N!"t"$.z.z;0N!-60000+"t"$.z.z;
16:31:16.789
16:30:16.789
```
after
```q
q)0N!"n"$.z.z;0N!-60000000000+"n"$.z.z;
0D16:31:16.774010000
0D16:30:16.774065000
```